### PR TITLE
service healthchecks

### DIFF
--- a/deployments/metastore/metastore.yaml
+++ b/deployments/metastore/metastore.yaml
@@ -21,7 +21,8 @@ spec:
             - -c
             - /opt/hive/bin/hive --service metastore --hiveconf javax.jdo.option.ConnectionPassword=${HIVE_USER_PWD}
           ports:
-            - containerPort: 9083
+            - name: metastore
+              containerPort: 9083
           env:
             - name: HIVE_CONF_DIR
               value: /opt/spark/conf
@@ -30,6 +31,16 @@ spec:
                 secretKeyRef:
                   name: hive
                   key: password
+          livenessProbe:
+            tcpSocket:
+              port: metastore
+            failureThreshold: 1
+            periodSeconds: 10
+          startupProbe:
+            tcpSocket:
+              port: metastore
+            failureThreshold: 6
+            periodSeconds: 20
 ---
 apiVersion: v1
 kind: Service

--- a/deployments/spark/spark-server.yaml
+++ b/deployments/spark/spark-server.yaml
@@ -24,14 +24,26 @@ spec:
             - name: warehouse-storage
               mountPath: /opt/spark-warehouse
           ports:
-            - containerPort: 10000
-            - containerPort: 4040
+            - name: thrift
+              containerPort: 10000
+            - name: spark-ui
+              containerPort: 4040
           env:
             - name: HIVE_USER_PWD
               valueFrom:
                 secretKeyRef:
                   name: hive
                   key: password
+          livenessProbe:
+            tcpSocket:
+              port: thrift
+            failureThreshold: 1
+            periodSeconds: 10
+          startupProbe:
+            tcpSocket:
+              port: thrift
+            failureThreshold: 6
+            periodSeconds: 20
       volumes:
         - name: google-credentials
           secret:
@@ -52,5 +64,5 @@ spec:
       name: thrift
       targetPort: 10000
     - port: 4040
-      name: ui
+      name: spark-ui
       targetPort: 4040


### PR DESCRIPTION
This PR contains the addition of two health and status checks for the metastore service and spark thriftserver. Specifically the thriftserver has a variable startup time due to external dependencies (e.g. Google) being downloaded. 

- Adding startupProbe checking if service is up and running within 2 min.
- Adding livenessProbe to check every 10 seconds if service is still running.